### PR TITLE
FIX:Refactorización para manejo de memoria con std::unique_ptr

### DIFF
--- a/src/ProgramaAcademico.cpp
+++ b/src/ProgramaAcademico.cpp
@@ -1,18 +1,15 @@
 #include "ProgramaAcademico.h"
+#include <iostream>
 
-using namespace std;
+ProgramaAcademico::ProgramaAcademico() : consolidados(8) {}
 
-ProgramaAcademico::ProgramaAcademico()
-{
-    consolidados = vector<Consolidado *>(8);
-}
-
+// Setters y Getters refactorizados con std::string_view en setters
 void ProgramaAcademico::setCodigoDeLaInstitucion(int nuevoCodigoDeLaInstitucion)
 {
     codigoDeLaInstitucion = nuevoCodigoDeLaInstitucion;
 }
 
-int ProgramaAcademico::getCodigoDeLaInstitucion()
+int ProgramaAcademico::getCodigoDeLaInstitucion() const
 {
     return codigoDeLaInstitucion;
 }
@@ -22,26 +19,27 @@ void ProgramaAcademico::setIesPadre(int nuevoIesPadre)
     iesPadre = nuevoIesPadre;
 }
 
-int ProgramaAcademico::getIesPadre()
+int ProgramaAcademico::getIesPadre() const
 {
     return iesPadre;
 }
 
-void ProgramaAcademico::setInstitucionDeEducacionSuperiorIes(string &nuevoInstitucionDeEducacionSuperiorIes)
+void ProgramaAcademico::setInstitucionDeEducacionSuperiorIes(std::string_view nuevoInstitucionDeEducacionSuperiorIes)
 {
     institucionDeEducacionSuperiorIes = nuevoInstitucionDeEducacionSuperiorIes;
 }
-string ProgramaAcademico::getInstitucionDeEducacionSuperiorIes()
+
+const std::string &ProgramaAcademico::getInstitucionDeEducacionSuperiorIes() const
 {
     return institucionDeEducacionSuperiorIes;
 }
 
-void ProgramaAcademico::setPrincipalOSeccional(string &nuevoPrincipalOSeccional)
+void ProgramaAcademico::setPrincipalOSeccional(std::string_view nuevoPrincipalOSeccional)
 {
     principalOSeccional = nuevoPrincipalOSeccional;
 }
 
-string ProgramaAcademico::getPrincipalOSeccional()
+const std::string &ProgramaAcademico::getPrincipalOSeccional() const
 {
     return principalOSeccional;
 }
@@ -51,17 +49,17 @@ void ProgramaAcademico::setIdSectorIes(int nuevoIdSectorIes)
     idSectorIes = nuevoIdSectorIes;
 }
 
-int ProgramaAcademico::getIdSectorIes()
+int ProgramaAcademico::getIdSectorIes() const
 {
     return idSectorIes;
 }
 
-void ProgramaAcademico::setSectorIes(string &nuevoSectorIes)
+void ProgramaAcademico::setSectorIes(std::string_view nuevoSectorIes)
 {
     sectorIes = nuevoSectorIes;
 }
 
-string ProgramaAcademico::getSectorIes()
+const std::string &ProgramaAcademico::getSectorIes() const
 {
     return sectorIes;
 }
@@ -71,17 +69,17 @@ void ProgramaAcademico::setIdCaracter(int nuevoIdCaracter)
     idCaracter = nuevoIdCaracter;
 }
 
-int ProgramaAcademico::getIdCaracter()
+int ProgramaAcademico::getIdCaracter() const
 {
     return idCaracter;
 }
 
-void ProgramaAcademico::setCaracterIes(string &nuevoCaracterIes)
+void ProgramaAcademico::setCaracterIes(std::string_view nuevoCaracterIes)
 {
     caracterIes = nuevoCaracterIes;
 }
 
-string ProgramaAcademico::getCaracterIes()
+const std::string &ProgramaAcademico::getCaracterIes() const
 {
     return caracterIes;
 }
@@ -91,17 +89,17 @@ void ProgramaAcademico::setCodigoDelDepartamentoIes(int nuevoCodigoDelDepartamen
     codigoDelDepartamentoIes = nuevoCodigoDelDepartamentoIes;
 }
 
-int ProgramaAcademico::getCodigoDelDepartamentoIes()
+int ProgramaAcademico::getCodigoDelDepartamentoIes() const
 {
     return codigoDelDepartamentoIes;
 }
 
-void ProgramaAcademico::setDepartamentoDeDomicilioDeLaIes(string &nuevoDepartamentoDeDomicilioDeLaIes)
+void ProgramaAcademico::setDepartamentoDeDomicilioDeLaIes(std::string_view nuevoDepartamentoDeDomicilioDeLaIes)
 {
     departamentoDeDomicilioDeLaIes = nuevoDepartamentoDeDomicilioDeLaIes;
 }
 
-string ProgramaAcademico::getDepartamentoDeDomicilioDeLaIes()
+const std::string &ProgramaAcademico::getDepartamentoDeDomicilioDeLaIes() const
 {
     return departamentoDeDomicilioDeLaIes;
 }
@@ -111,17 +109,17 @@ void ProgramaAcademico::setCodigoDelMunicipioIes(int nuevoCodigoDelMunicipioIes)
     codigoDelMunicipioIes = nuevoCodigoDelMunicipioIes;
 }
 
-int ProgramaAcademico::getCodigoDelMunicipioIes()
+int ProgramaAcademico::getCodigoDelMunicipioIes() const
 {
     return codigoDelMunicipioIes;
 }
 
-void ProgramaAcademico::setMunicipioDeDomicilioDeLaIes(string &nuevoMunicipioDeDomicilioDeLaIes)
+void ProgramaAcademico::setMunicipioDeDomicilioDeLaIes(std::string_view nuevoMunicipioDeDomicilioDeLaIes)
 {
     municipioDeDomicilioDeLaIes = nuevoMunicipioDeDomicilioDeLaIes;
 }
 
-string ProgramaAcademico::getMunicipioDeDomicilioDeLaIes()
+const std::string &ProgramaAcademico::getMunicipioDeDomicilioDeLaIes() const
 {
     return municipioDeDomicilioDeLaIes;
 }
@@ -131,17 +129,17 @@ void ProgramaAcademico::setCodigoSniesDelPrograma(int nuevoCodigoSniesDelProgram
     codigoSniesDelPrograma = nuevoCodigoSniesDelPrograma;
 }
 
-int ProgramaAcademico::getCodigoSniesDelPrograma()
+int ProgramaAcademico::getCodigoSniesDelPrograma() const
 {
     return codigoSniesDelPrograma;
 }
 
-void ProgramaAcademico::setProgramaAcademico(string &nuevoProgramaAcademico)
+void ProgramaAcademico::setProgramaAcademico(std::string_view nuevoProgramaAcademico)
 {
     programaAcademico = nuevoProgramaAcademico;
 }
 
-string ProgramaAcademico::getProgramaAcademico()
+const std::string &ProgramaAcademico::getProgramaAcademico() const
 {
     return programaAcademico;
 }
@@ -151,17 +149,17 @@ void ProgramaAcademico::setIdNivelAcademico(int nuevoIdNivelAcademico)
     idNivelAcademico = nuevoIdNivelAcademico;
 }
 
-int ProgramaAcademico::getIdNivelAcademico()
+int ProgramaAcademico::getIdNivelAcademico() const
 {
     return idNivelAcademico;
 }
 
-void ProgramaAcademico::setNivelAcademico(string &nuevoNivelAcademico)
+void ProgramaAcademico::setNivelAcademico(std::string_view nuevoNivelAcademico)
 {
     nivelAcademico = nuevoNivelAcademico;
 }
 
-string ProgramaAcademico::getNivelAcademico()
+const std::string &ProgramaAcademico::getNivelAcademico() const
 {
     return nivelAcademico;
 }
@@ -171,17 +169,17 @@ void ProgramaAcademico::setIdNivelDeFormacion(int nuevoIdNivelDeFormacion)
     idNivelDeFormacion = nuevoIdNivelDeFormacion;
 }
 
-int ProgramaAcademico::getIdNivelDeFormacion()
+int ProgramaAcademico::getIdNivelDeFormacion() const
 {
     return idNivelDeFormacion;
 }
 
-void ProgramaAcademico::setNivelDeFormacion(string &nuevoNivelDeFormacion)
+void ProgramaAcademico::setNivelDeFormacion(std::string_view nuevoNivelDeFormacion)
 {
     nivelDeFormacion = nuevoNivelDeFormacion;
 }
 
-string ProgramaAcademico::getNivelDeFormacion()
+const std::string &ProgramaAcademico::getNivelDeFormacion() const
 {
     return nivelDeFormacion;
 }
@@ -191,17 +189,17 @@ void ProgramaAcademico::setIdMetodologia(int nuevoIdMetodologia)
     idMetodologia = nuevoIdMetodologia;
 }
 
-int ProgramaAcademico::getIdMetodologia()
+int ProgramaAcademico::getIdMetodologia() const
 {
     return idMetodologia;
 }
 
-void ProgramaAcademico::setMetodologia(string &nuevaMetodologia)
+void ProgramaAcademico::setMetodologia(std::string_view nuevaMetodologia)
 {
     metodologia = nuevaMetodologia;
 }
 
-string ProgramaAcademico::getMetodologia()
+const std::string &ProgramaAcademico::getMetodologia() const
 {
     return metodologia;
 }
@@ -211,16 +209,17 @@ void ProgramaAcademico::setIdArea(int nuevoIdArea)
     idArea = nuevoIdArea;
 }
 
-int ProgramaAcademico::getIdArea()
+int ProgramaAcademico::getIdArea() const
 {
     return idArea;
 }
 
-void ProgramaAcademico::setAreaDeConocimiento(string &areaConocimiento)
+void ProgramaAcademico::setAreaDeConocimiento(std::string_view areaConocimiento)
 {
     areaDeConocimiento = areaConocimiento;
 }
-string ProgramaAcademico::getAreaDeConocimiento()
+
+const std::string &ProgramaAcademico::getAreaDeConocimiento() const
 {
     return areaDeConocimiento;
 }
@@ -229,16 +228,18 @@ void ProgramaAcademico::setIdNucleo(int nuevoIdNucleo)
 {
     idNucleo = nuevoIdNucleo;
 }
-int ProgramaAcademico::getIdNucleo()
+
+int ProgramaAcademico::getIdNucleo() const
 {
     return idNucleo;
 }
 
-void ProgramaAcademico::setNucleoBasicoDelConocimientoNbc(string &nuevoNucleoBasicoDelConocimientoNbc)
+void ProgramaAcademico::setNucleoBasicoDelConocimientoNbc(std::string_view nuevoNucleoBasicoDelConocimientoNbc)
 {
     nucleoBasicoDelConocimientoNbc = nuevoNucleoBasicoDelConocimientoNbc;
 }
-string ProgramaAcademico::getNucleoBasicoDelConocimientoNbc()
+
+const std::string &ProgramaAcademico::getNucleoBasicoDelConocimientoNbc() const
 {
     return nucleoBasicoDelConocimientoNbc;
 }
@@ -247,16 +248,18 @@ void ProgramaAcademico::setIdCineCampoAmplio(int nuevoIdCineCampoAmplio)
 {
     idCineCampoAmplio = nuevoIdCineCampoAmplio;
 }
-int ProgramaAcademico::getIdCineCampoAmplio()
+
+int ProgramaAcademico::getIdCineCampoAmplio() const
 {
     return idCineCampoAmplio;
 }
 
-void ProgramaAcademico::setDescCineCampoAmplio(string &nuevoDescCineCampoAmplio)
+void ProgramaAcademico::setDescCineCampoAmplio(std::string_view nuevoDescCineCampoAmplio)
 {
     descCineCampoAmplio = nuevoDescCineCampoAmplio;
 }
-string ProgramaAcademico::getDescCineCampoAmplio()
+
+const std::string &ProgramaAcademico::getDescCineCampoAmplio() const
 {
     return descCineCampoAmplio;
 }
@@ -265,17 +268,18 @@ void ProgramaAcademico::setIdCineCampoEspecifico(int nuevoIdCineCampoEspecifico)
 {
     idCineCampoEspecifico = nuevoIdCineCampoEspecifico;
 }
-int ProgramaAcademico::getIdCineCampoEspecifico()
+
+int ProgramaAcademico::getIdCineCampoEspecifico() const
 {
     return idCineCampoEspecifico;
 }
 
-void ProgramaAcademico::setDescCineCampoEspecifico(string &nuevoDescCineCampoEspecifico)
+void ProgramaAcademico::setDescCineCampoEspecifico(std::string_view nuevoDescCineCampoEspecifico)
 {
     descCineCampoEspecifico = nuevoDescCineCampoEspecifico;
 }
 
-string ProgramaAcademico::getDescCineCampoEspecifico()
+const std::string &ProgramaAcademico::getDescCineCampoEspecifico() const
 {
     return descCineCampoEspecifico;
 }
@@ -284,16 +288,18 @@ void ProgramaAcademico::setIdCineCodigoDetallado(int nuevoIdCineCodigoDetallado)
 {
     idCineCodigoDetallado = nuevoIdCineCodigoDetallado;
 }
-int ProgramaAcademico::getIdCineCodigoDetallado()
+
+int ProgramaAcademico::getIdCineCodigoDetallado() const
 {
     return idCineCodigoDetallado;
 }
 
-void ProgramaAcademico::setDescCineCodigoDetallado(string &nuevoDescCineCodigoDetallado)
+void ProgramaAcademico::setDescCineCodigoDetallado(std::string_view nuevoDescCineCodigoDetallado)
 {
     descCineCodigoDetallado = nuevoDescCineCodigoDetallado;
 }
-string ProgramaAcademico::getDescCineCodigoDetallado()
+
+const std::string &ProgramaAcademico::getDescCineCodigoDetallado() const
 {
     return descCineCodigoDetallado;
 }
@@ -302,16 +308,18 @@ void ProgramaAcademico::setCodigoDelDepartamentoPrograma(int nuevoCodigoDelDepar
 {
     codigoDelDepartamentoPrograma = nuevoCodigoDelDepartamentoPrograma;
 }
-int ProgramaAcademico::getCodigoDelDepartamentoPrograma()
+
+int ProgramaAcademico::getCodigoDelDepartamentoPrograma() const
 {
     return codigoDelDepartamentoPrograma;
 }
 
-void ProgramaAcademico::setDepartamentoDeOfertaDelPrograma(string &nuevoDepartamentoDeOfertaDelPrograma)
+void ProgramaAcademico::setDepartamentoDeOfertaDelPrograma(std::string_view nuevoDepartamentoDeOfertaDelPrograma)
 {
     departamentoDeOfertaDelPrograma = nuevoDepartamentoDeOfertaDelPrograma;
 }
-string ProgramaAcademico::getDepartamentoDeOfertaDelPrograma()
+
+const std::string &ProgramaAcademico::getDepartamentoDeOfertaDelPrograma() const
 {
     return departamentoDeOfertaDelPrograma;
 }
@@ -320,34 +328,40 @@ void ProgramaAcademico::setCodigoDelMunicipioPrograma(int nuevoCodigoDelMunicipi
 {
     codigoDelMunicipioPrograma = nuevoCodigoDelMunicipioPrograma;
 }
-int ProgramaAcademico::getCodigoDelMunicipioPrograma()
+
+int ProgramaAcademico::getCodigoDelMunicipioPrograma() const
 {
     return codigoDelMunicipioPrograma;
 }
 
-void ProgramaAcademico::setMunicipioDeOfertaDelPrograma(string &nuevoMunicipioDeOfertaDelPrograma)
+void ProgramaAcademico::setMunicipioDeOfertaDelPrograma(std::string_view nuevoMunicipioDeOfertaDelPrograma)
 {
     municipioDeOfertaDelPrograma = nuevoMunicipioDeOfertaDelPrograma;
 }
-string ProgramaAcademico::getMunicipioDeOfertaDelPrograma()
+
+const std::string &ProgramaAcademico::getMunicipioDeOfertaDelPrograma() const
 {
     return municipioDeOfertaDelPrograma;
 }
 
-void ProgramaAcademico::setConsolidado(Consolidado *nuevoConsolidado, int pos)
+void ProgramaAcademico::setConsolidado(std::unique_ptr<Consolidado> nuevoConsolidado, int pos)
 {
-    consolidados[pos] = nuevoConsolidado;
-}
-
-Consolidado *ProgramaAcademico::getConsolidado(int posicionConsolidado)
-{
-    return consolidados[posicionConsolidado];
-}
-
-ProgramaAcademico::~ProgramaAcademico()
-{
-    for (Consolidado *consolidado : consolidados)
+    if (pos >= 0 && pos < consolidados.size())
     {
-        delete consolidado;
+        consolidados[pos] = std::move(nuevoConsolidado);  // Asignamos con std::move para transferir la propiedad
     }
+    else
+    {
+        std::cerr << "Error: Posición fuera de rango al intentar establecer un consolidado." << std::endl;
+    }
+}
+
+Consolidado *ProgramaAcademico::getConsolidado(int posicionConsolidado) const
+{
+    if (posicionConsolidado >= 0 && posicionConsolidado < consolidados.size())
+    {
+        return consolidados[posicionConsolidado].get();  // Accedemos al puntero gestionado
+    }
+    std::cerr << "Error: Posición fuera de rango al intentar obtener un consolidado." << std::endl;
+    return nullptr;
 }

--- a/src/ProgramaAcademico.h
+++ b/src/ProgramaAcademico.h
@@ -3,146 +3,157 @@
 
 #include <string>
 #include <vector>
-#include <iostream>
+#include <string_view>
+#include <memory>
 #include "Consolidado.h"
-
-using std::cin;
-using std::cout;
-using std::endl;
-using std::string;
-using std::vector;
 
 class ProgramaAcademico
 {
     int codigoDeLaInstitucion;
     int iesPadre;
-    string institucionDeEducacionSuperiorIes;
-    string principalOSeccional;
+    std::string institucionDeEducacionSuperiorIes;
+    std::string principalOSeccional;
     int idSectorIes;
-    string sectorIes;
+    std::string sectorIes;
     int idCaracter;
-    string caracterIes;
+    std::string caracterIes;
     int codigoDelDepartamentoIes;
-    string departamentoDeDomicilioDeLaIes;
+    std::string departamentoDeDomicilioDeLaIes;
     int codigoDelMunicipioIes;
-    string municipioDeDomicilioDeLaIes;
+    std::string municipioDeDomicilioDeLaIes;
     int codigoSniesDelPrograma;
-    string programaAcademico;
+    std::string programaAcademico;
     int idNivelAcademico;
-    string nivelAcademico;
+    std::string nivelAcademico;
     int idNivelDeFormacion;
-    string nivelDeFormacion;
+    std::string nivelDeFormacion;
     int idMetodologia;
-    string metodologia;
+    std::string metodologia;
     int idArea;
-    string areaDeConocimiento;
+    std::string areaDeConocimiento;
     int idNucleo;
-    string nucleoBasicoDelConocimientoNbc;
+    std::string nucleoBasicoDelConocimientoNbc;
     int idCineCampoAmplio;
-    string descCineCampoAmplio;
+    std::string descCineCampoAmplio;
     int idCineCampoEspecifico;
-    string descCineCampoEspecifico;
+    std::string descCineCampoEspecifico;
     int idCineCodigoDetallado;
-    string descCineCodigoDetallado;
+    std::string descCineCodigoDetallado;
     int codigoDelDepartamentoPrograma;
-    string departamentoDeOfertaDelPrograma;
+    std::string departamentoDeOfertaDelPrograma;
     int codigoDelMunicipioPrograma;
-    string municipioDeOfertaDelPrograma;
-    vector<Consolidado *> consolidados;
+    std::string municipioDeOfertaDelPrograma;
+    std::vector<std::unique_ptr<Consolidado>> consolidados;
 
 public:
     ProgramaAcademico();
 
     void setCodigoDeLaInstitucion(int);
-    int getCodigoDeLaInstitucion();
+    int getCodigoDeLaInstitucion() const;
 
     void setIesPadre(int);
-    int getIesPadre();
+    int getIesPadre() const;
 
-    void setInstitucionDeEducacionSuperiorIes(string &);
-    string getInstitucionDeEducacionSuperiorIes();
+    void setInstitucionDeEducacionSuperiorIes(std::string_view);
+    const std::string &getInstitucionDeEducacionSuperiorIes() const;
 
-    void setPrincipalOSeccional(string &);
-    string getPrincipalOSeccional();
+    void setPrincipalOSeccional(std::string_view);
+    const std::string &getPrincipalOSeccional() const;
 
     void setIdSectorIes(int);
-    int getIdSectorIes();
+    int getIdSectorIes() const;
 
-    void setSectorIes(string &);
-    string getSectorIes();
+    void setSectorIes(std::string_view);
+    const std::string &getSectorIes() const;
 
     void setIdCaracter(int);
-    int getIdCaracter();
+    int getIdCaracter() const;
 
-    void setCaracterIes(string &);
-    string getCaracterIes();
+    void setCaracterIes(std::string_view);
+    const std::string &getCaracterIes() const;
 
     void setCodigoDelDepartamentoIes(int);
-    int getCodigoDelDepartamentoIes();
+    int getCodigoDelDepartamentoIes() const;
 
-    void setDepartamentoDeDomicilioDeLaIes(string &);
-    string getDepartamentoDeDomicilioDeLaIes();
+    void setDepartamentoDeDomicilioDeLaIes(std::string_view);
+    const std::string &getDepartamentoDeDomicilioDeLaIes() const;
 
     void setCodigoDelMunicipioIes(int);
-    int getCodigoDelMunicipioIes();
+    int getCodigoDelMunicipioIes() const;
 
-    void setMunicipioDeDomicilioDeLaIes(string &);
-    string getMunicipioDeDomicilioDeLaIes();
+    void setMunicipioDeDomicilioDeLaIes(std::string_view);
+    const std::string &getMunicipioDeDomicilioDeLaIes() const;
 
     void setCodigoSniesDelPrograma(int);
-    int getCodigoSniesDelPrograma();
+    int getCodigoSniesDelPrograma() const;
 
-    void setProgramaAcademico(string &);
-    string getProgramaAcademico();
+    void setProgramaAcademico(std::string_view);
+    const std::string &getProgramaAcademico() const;
 
     void setIdNivelAcademico(int);
-    int getIdNivelAcademico();
+    int getIdNivelAcademico() const;
 
-    void setNivelAcademico(string &);
-    string getNivelAcademico();
+    void setNivelAcademico(std::string_view);
+    const std::string &getNivelAcademico() const;
 
     void setIdNivelDeFormacion(int);
-    int getIdNivelDeFormacion();
+    int getIdNivelDeFormacion() const;
 
-    void setNivelDeFormacion(string &);
-    string getNivelDeFormacion();
+    void setNivelDeFormacion(std::string_view);  // Cambio aquí a std::string_view
+    const std::string &getNivelDeFormacion() const;
 
     void setIdMetodologia(int);
-    int getIdMetodologia();
-    void setMetodologia(string &);
-    string getMetodologia();
+    int getIdMetodologia() const;
+
+    void setMetodologia(std::string_view);
+    const std::string &getMetodologia() const;
 
     void setIdArea(int);
-    int getIdArea();
-    void setAreaDeConocimiento(string &);
-    string getAreaDeConocimiento();
+    int getIdArea() const;
+
+    void setAreaDeConocimiento(std::string_view);
+    const std::string &getAreaDeConocimiento() const;
+
     void setIdNucleo(int);
-    int getIdNucleo();
-    void setNucleoBasicoDelConocimientoNbc(string &);
-    string getNucleoBasicoDelConocimientoNbc();
+    int getIdNucleo() const;
+
+    void setNucleoBasicoDelConocimientoNbc(std::string_view);
+    const std::string &getNucleoBasicoDelConocimientoNbc() const;
+
     void setIdCineCampoAmplio(int);
-    int getIdCineCampoAmplio();
-    void setDescCineCampoAmplio(string &);
-    string getDescCineCampoAmplio();
+    int getIdCineCampoAmplio() const;
+
+    void setDescCineCampoAmplio(std::string_view);
+    const std::string &getDescCineCampoAmplio() const;
+
     void setIdCineCampoEspecifico(int);
-    int getIdCineCampoEspecifico();
-    void setDescCineCampoEspecifico(string &);
-    string getDescCineCampoEspecifico();
+    int getIdCineCampoEspecifico() const;
+
+    void setDescCineCampoEspecifico(std::string_view);
+    const std::string &getDescCineCampoEspecifico() const;
+
     void setIdCineCodigoDetallado(int);
-    int getIdCineCodigoDetallado();
-    void setDescCineCodigoDetallado(string &);
-    string getDescCineCodigoDetallado();
+    int getIdCineCodigoDetallado() const;
+
+    void setDescCineCodigoDetallado(std::string_view);
+    const std::string &getDescCineCodigoDetallado() const;
+
     void setCodigoDelDepartamentoPrograma(int);
-    int getCodigoDelDepartamentoPrograma();
-    void setDepartamentoDeOfertaDelPrograma(string &);
-    string getDepartamentoDeOfertaDelPrograma();
+    int getCodigoDelDepartamentoPrograma() const;
+
+    void setDepartamentoDeOfertaDelPrograma(std::string_view);
+    const std::string &getDepartamentoDeOfertaDelPrograma() const;
+
     void setCodigoDelMunicipioPrograma(int);
-    int getCodigoDelMunicipioPrograma();
-    void setMunicipioDeOfertaDelPrograma(string &);
-    string getMunicipioDeOfertaDelPrograma();
-    void setConsolidado(Consolidado *, int);
-    Consolidado *getConsolidado(int);
-    ~ProgramaAcademico();
+    int getCodigoDelMunicipioPrograma() const;
+
+    void setMunicipioDeOfertaDelPrograma(std::string_view);
+    const std::string &getMunicipioDeOfertaDelPrograma() const;
+
+    void setConsolidado(std::unique_ptr<Consolidado> nuevoConsolidado, int pos);
+    Consolidado *getConsolidado(int) const;
+
+    ~ProgramaAcademico() = default;
 };
 
 #endif

--- a/src/SNIESController.cpp
+++ b/src/SNIESController.cpp
@@ -83,7 +83,7 @@ void SNIESController::procesarDatosCsv(string &ano1, string &ano2)
             consolidado[m]->setAno(stoi(programasAcademicosVector[i + m][36]));
             consolidado[m]->setSemestre(stoi(programasAcademicosVector[i + m][37]));
             consolidado[m]->setAdmitidos(stoi(programasAcademicosVector[i + m][38]));
-            programaAcademico->setConsolidado(consolidado[m], m);
+            programaAcademico->setConsolidado(std::make_unique<Consolidado>(*(consolidado[m])), m);
         }
         programasAcademicos.emplace(programaAcademico->getCodigoSniesDelPrograma(), programaAcademico);
     }
@@ -106,7 +106,7 @@ void SNIESController::procesarDatosCsv(string &ano1, string &ano2)
                 consolidado[m]->setAno(stoi(programasAcademicosVector[j + m][3]));
                 consolidado[m]->setSemestre(stoi(programasAcademicosVector[j + m][4]));
                 consolidado[m]->setAdmitidos(stoi(programasAcademicosVector[j + m][5]));
-                programa->setConsolidado(consolidado[m], m + 4);
+                programa->setConsolidado(std::make_unique<Consolidado>(*(consolidado[m])), m + 4);
             }
         }
     }


### PR DESCRIPTION
- Se refactorizó la clase ProgramaAcademico para usar std::unique_ptr en lugar de punteros sin gestionar para mejorar la gestión automática de memoria. 
- Se introdujo std::string_view en los setters para optimizar el rendimiento.
- Eliminación de delete manual en el destructor.
- Se mejoró el manejo de memoria y rendimiento.