### PR TITLE
FIX:Refactorización y resolución de conflictos de sombreado

### DIFF
--- a/src/Consolidado.cpp
+++ b/src/Consolidado.cpp
@@ -1,95 +1,79 @@
 #include "Consolidado.h"
+#include <string>
 
 Consolidado::Consolidado() = default;
 
-Consolidado::Consolidado(int idSexo, string sexo, int ano, int semestre, int inscritos, int admitidos, int primeraMatricula, int totalMatriculados, int graduados)
-    : idSexo(idSexo), sexo(sexo), ano(ano), semestre(semestre), inscritos(inscritos), admitidos(admitidos), matriculados(primeraMatricula), matriculadosPrimerSemestre(totalMatriculados), graduados(graduados) {}
+Consolidado::Consolidado(int idSexo, std::string_view sexo, int ano, int semestre, const DatosEstudiantes &datosEstudiantes)
+    : idSexo(idSexo), sexo(sexo), ano(ano), semestre(semestre), datosEstudiantes(datosEstudiantes) {}
 
-int Consolidado::getIdSexo()
-{
+int Consolidado::getIdSexo() const {
     return idSexo;
 }
 
-void Consolidado::setIdSexo(int idSexo)
-{
-    this->idSexo = idSexo;
+void Consolidado::setIdSexo(int nuevoIdSexo) {
+    this->idSexo = nuevoIdSexo;
 }
 
-string Consolidado::getSexo()
-{
+std::string Consolidado::getSexo() const {
     return sexo;
 }
 
-void Consolidado::setSexo(string &sexo)
-{
-    this->sexo = sexo;
+void Consolidado::setSexo(std::string_view nuevoSexo) {
+    this->sexo = nuevoSexo;
 }
 
-int Consolidado::getAno()
-{
+int Consolidado::getAno() const {
     return ano;
 }
 
-void Consolidado::setAno(int ano)
-{
-    this->ano = ano;
+void Consolidado::setAno(int nuevoAno) {
+    this->ano = nuevoAno;
 }
 
-int Consolidado::getSemestre()
-{
+int Consolidado::getSemestre() const {
     return semestre;
 }
-void Consolidado::setSemestre(int semestre)
-{
-    this->semestre = semestre;
+
+void Consolidado::setSemestre(int nuevoSemestre) {
+    this->semestre = nuevoSemestre;
 }
 
-int Consolidado::getInscritos()
-{
-    return inscritos;
+int Consolidado::getInscritos() const {
+    return datosEstudiantes.inscritos;
 }
 
-void Consolidado::setInscritos(int inscritos)
-{
-    this->inscritos = inscritos;
+void Consolidado::setInscritos(int inscritos) {
+    datosEstudiantes.inscritos = inscritos;
 }
 
-int Consolidado::getAdmitidos()
-{
-    return admitidos;
+int Consolidado::getAdmitidos()  const{
+    return datosEstudiantes.admitidos;
 }
 
-void Consolidado::setAdmitidos(int admitidos)
-{
-    this->admitidos = admitidos;
+void Consolidado::setAdmitidos(int admitidos) {
+    datosEstudiantes.admitidos = admitidos;
 }
 
-int Consolidado::getMatriculados()
-{
-    return matriculados;
+int Consolidado::getMatriculados()  const{
+    return datosEstudiantes.matriculados;
 }
 
-void Consolidado::setMatriculados(int matriculados)
-{
-    this->matriculados = matriculados;
+void Consolidado::setMatriculados(int matriculados) {
+    datosEstudiantes.matriculados = matriculados;
 }
 
-int Consolidado::getMatriculadosPrimerSemestre()
-{
-    return matriculadosPrimerSemestre;
+int Consolidado::getMatriculadosPrimerSemestre() const {
+    return datosEstudiantes.matriculadosPrimerSemestre;
 }
 
-void Consolidado::setMatriculadosPrimerSemestre(int matriculadosPrimerSemestre)
-{
-    this->matriculadosPrimerSemestre = matriculadosPrimerSemestre;
+void Consolidado::setMatriculadosPrimerSemestre(int matriculadosPrimerSemestre) {
+    datosEstudiantes.matriculadosPrimerSemestre = matriculadosPrimerSemestre;
 }
 
-int Consolidado::getGraduados()
-{
-    return graduados;
+int Consolidado::getGraduados()  const{
+    return datosEstudiantes.graduados;
 }
 
-void Consolidado::setGraduados(int graduados)
-{
-    this->graduados = graduados;
+void Consolidado::setGraduados(int graduados) {
+    datosEstudiantes.graduados = graduados;
 }

--- a/src/Consolidado.h
+++ b/src/Consolidado.h
@@ -2,62 +2,52 @@
 #define CONSOLIDADO_H
 
 #include <string>
-#include <vector>
-#include <iostream>
-
-
-using std::cin;
-using std::cout;
-using std::endl;
-using std::string;
-using std::vector;
-
-
-class Consolidado
-{
-private:
-    int idSexo;
-    string sexo;
-    int ano;
-    int semestre;
+struct DatosEstudiantes {
     int inscritos;
     int admitidos;
     int matriculados;
     int matriculadosPrimerSemestre;
     int graduados;
+};
+
+class Consolidado {
+private:
+    int idSexo;
+    std::string sexo;
+    int ano;
+    int semestre;
+    DatosEstudiantes datosEstudiantes;
 
 public:
     Consolidado();
-    // Mantenimiento: Gran cantidad de atributos en la firma del constructor
-    Consolidado(int, string, int, int, int, int, int, int, int);
+    Consolidado(int idSexo, std::string_view sexo, int ano, int semestre, const DatosEstudiantes &datosEstudiantes);
 
-    // Mantenimiento: Gran cantidad de métodos get y set que tal vez no son estrictamente necesarios
-    int getIdSexo();
-    void setIdSexo(int);
+    int getIdSexo() const;
+    void setIdSexo(int idSexo);
 
-    string getSexo();
-    void setSexo(string &);
+    std::string getSexo() const;
+    void setSexo(std::string_view sexo);
 
-    int getAno();
-    void setAno(int);
+    int getAno() const;
+    void setAno(int ano);
 
-    int getSemestre();
-    void setSemestre(int);
+    int getSemestre() const;
+    void setSemestre(int semestre);
 
-    int getInscritos();
-    void setInscritos(int);
+    int getInscritos() const;
+    void setInscritos(int inscritos);
 
-    int getAdmitidos();
-    void setAdmitidos(int);
+    int getAdmitidos() const;
+    void setAdmitidos(int admitidos);
 
-    int getMatriculados();
-    void setMatriculados(int);
+    int getMatriculados() const;
+    void setMatriculados(int matriculados);
 
-    int getMatriculadosPrimerSemestre();
-    void setMatriculadosPrimerSemestre(int);
+    int getMatriculadosPrimerSemestre() const;
+    void setMatriculadosPrimerSemestre(int matriculadosPrimerSemestre);
 
-    int getGraduados();
-    void setGraduados(int);
+    int getGraduados() const;
+    void setGraduados(int graduados);
 };
 
 #endif // CONSOLIDADO_H


### PR DESCRIPTION
- Se dividió el constructor que originalmente tenía 9 parámetros, siguiendo el principio de mantener un número manejable de argumentos.
- Reemplazo de referencias a std::string por std::string_view.
- Se modificaron los nombres de variables en los setters para evitar conflictos con los atributos de la clase.
- Mejoras generales de legibilidad y mantenimiento.